### PR TITLE
Only call the `get_current_screen` function if it is defined

### DIFF
--- a/relevanssi.php
+++ b/relevanssi.php
@@ -103,8 +103,10 @@ function relevanssi_didyoumean($query, $pre, $post, $n = 5, $echo = true) {
 }
 
 function relevanssi_check_old_data() {
-	$screen = get_current_screen();
-	if ($screen->base != 'settings_page_relevanssi-premium/relevanssi') return;
+	if (function_exists('get_current_screen')) {
+		$screen = get_current_screen();
+		if ($screen->base != 'settings_page_relevanssi-premium/relevanssi') return;
+	}
 
 	if (is_admin()) {
 		// Version 3.3 removes the cache feature


### PR DESCRIPTION
Relevanssi uses the `get_current_screen` function within the `admin_head` hook.

The problem with this is, as the Wordpress docs specify:

> do_action( 'admin_head' )
> Fires in head section for all admin pages.
(https://developer.wordpress.org/reference/hooks/admin_head/)

And `get_current_screen`:

> **This function is defined on most admin pages, but not all.** Thus there are cases where is_admin() will return true, but attempting to call get_current_screen() will result in a fatal error because it is not defined.
(https://codex.wordpress.org/Function_Reference/get_current_screen)

This creates problems in some situations, for me, it caused a fatal error when using the Wordpress OpenID plugin (https://wordpress.org/plugins/openid/). I'm not sure if it creates problems with other pages (but I believe it has the potential to).

This PR changes the function call, so that the function is only called if it exists. I believe this is an appropriate solution to the problem.

(This is actually my first public PR on Github, so if I've done anything stupid/not kept to standard etiquette, please let me know!)