### PR TITLE
Fix for highlighting words with accent variations

### DIFF
--- a/lib/excerpts-highlights.php
+++ b/lib/excerpts-highlights.php
@@ -787,8 +787,8 @@ function relevanssi_count_matches( $words, $complete_text ) {
 
 	$count_words = count( $words );
 	for ( $t = 0; $t < $count_words; $t++ ) {
-		$word_slice = relevanssi_strtolower( $words[ $t ], 'UTF-8' );
-		$lines      = explode( $word_slice, $lowercase_text );
+		$word_slice = relevanssi_strtolower( relevanssi_add_accent_variations( $words[ $t ] ), 'UTF-8' );
+		$lines      = preg_split( "/$word_slice/", $lowercase_text );
 		if ( count( $lines ) > 1 ) {
 			$count_lines = count( $lines );
 			for ( $tt = 0; $tt < $count_lines; $tt++ ) {


### PR DESCRIPTION
Aloha Mikko,

Thanks for an awesome plugin that makes WordPress search so much better! We had a small regression after updating from 4.0.4 to 4.0.5, specifically with your refactor of `relevanssi_count_matches()`: https://github.com/msaari/relevanssi/commit/8815452ff44d6882f504f3bf354865877769e4fd#diff-2c88ef1f0812582c86e288ae654135dc

Our search excerpt highlights stopped working for certain words with accent variations (for example, we have hooked into `relevanssi_accents_replacement_arrays` to allow searches for "hawaii" to highlight variations with the proper Hawaiian language spelling like "hawai‘i" or "hawai'i").

After a little investigation, the quick fix in this pull request restores functionality. It basically just adds back the call to `relevanssi_add_accent_variations()` and uses `preg_split()` instead of `explode()`.

Let us know if you need any more info to get this integrated! 

Cheers,
-paul
