### PR TITLE
ACF Compatibility: Only use value if not an array or object

### DIFF
--- a/lib/compatibility/acf.php
+++ b/lib/compatibility/acf.php
@@ -66,7 +66,7 @@ function relevanssi_index_acf( &$insert_data, $post_id, $field_name, $field_valu
 	}
 
 	$value = $field_object['choices'][ $field_value ];
-	if ( $value ) {
+	if ( $value && ! is_array( $value ) && ! is_object( $value ) ) {
 		if ( ! isset( $insert_data[ $value ]['customfield'] ) ) {
 			$insert_data[ $value ]['customfield'] = 0;
 		}


### PR DESCRIPTION
Certain ACF extensions create the choices array dynamically as an array or object. This causes a PHP warning when attempting to insert the value. 

Full warning message:
```
PHP Warning:  Illegal offset type in /Users/adamtaylor/Sites/invest-wm/wp-content/plugins/relevanssi/lib/compatibility/acf.php on line 71
```

See https://github.com/7studio/acf-svg-icon as an example.

Note: I would have preferred to pull through some value instead of skipping the field entirely, but since it is impossible to know the array or object's structure, I thought this was the best compromise.