### PR TITLE
suppress php notice

### DIFF
--- a/lib/excerpts-highlights.php
+++ b/lib/excerpts-highlights.php
@@ -1103,7 +1103,7 @@ function relevanssi_get_custom_field_content( $post_id ) {
 
 				// Flatten other array data.
 				if ( is_array( $value ) ) {
-					$value = implode( ' ', $value );
+					$value = @implode( ' ', $value );
 				}
 				$custom_field_content .= ' ' . $value;
 			}


### PR DESCRIPTION
Some of the content being searched are multi-dimensional arrays (eg. a post created by SiteOrigins page builder) which triggers:

```
PHP Notice:  Array to string conversion in /path/to/wp-content/plugins/relevanssi/lib/excerpts-highlights.php on line 1106
```