### PR TITLE
Fix relevanssi_update_counts cronjob event

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -46,6 +46,7 @@ add_filter( 'relevanssi_remove_punctuation', 'relevanssi_remove_punct' );
 add_filter( 'relevanssi_post_ok', 'relevanssi_default_post_ok', 9, 2 );
 add_filter( 'relevanssi_query_filter', 'relevanssi_limit_filter' );
 add_action( 'relevanssi_trim_logs', 'relevanssi_trim_logs' );
+add_action( 'relevanssi_update_counts', 'relevanssi_update_counts' );
 add_action( 'relevanssi_custom_field_value', 'relevanssi_filter_custom_fields', 10, 2 );
 
 // Page builder shortcodes.


### PR DESCRIPTION
`relevanssi_update_counts` function was not called by the cronjob event because there was no action set.