### PR TITLE
Allow developers to trigger custom query without relevanssi_do_query & performance boots

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -17,7 +17,7 @@ add_action( 'admin_init', 'relevanssi_admin_init' );
 add_action( 'admin_menu', 'relevanssi_menu' );
 
 // Taking over the search.
-add_filter( 'the_posts', 'relevanssi_query', 99, 2 );
+add_filter( 'posts_pre_query', 'relevanssi_query', 99, 2 );
 add_filter( 'posts_request', 'relevanssi_prevent_default_request', 10, 2 );
 add_filter( 'relevanssi_search_ok', 'relevanssi_block_on_admin_searches', 10, 2 );
 add_filter( 'relevanssi_admin_search_ok', 'relevanssi_block_on_admin_searches', 10, 2 );

--- a/lib/search.php
+++ b/lib/search.php
@@ -60,6 +60,10 @@ function relevanssi_query( $posts, $query = false ) {
 		}
 	}
 
+	if ( $query->get( 'relevanssi' ) ) {
+		$search_ok = true; // Manual override, always search.
+	}
+
 	/**
 	 * Filters whether Relevanssi search can be run or not.
 	 *


### PR DESCRIPTION
Hi @msaari 

Originally I found the [relevanssi_do_query](https://www.relevanssi.com/user-manual/functions/relevanssi_do_query/) page.

Which doesn't work with a `pre_get_posts` hook on the main_query).
The page seems to suggest to create my own fully new WP_Query on a the `archive-cpt.php` and not use the main query.  This is [bad for performance](https://wordpress.stackexchange.com/questions/1753/when-should-you-use-wp-query-vs-query-posts-vs-get-posts) because you will run 2 queries for the same page, and the main query isn't even used.
This should also work on premium, I was working on premium when I ran into this problem.

So I created an option to pass `'relevanssi' => true` to any WP_Query and have it trigger Relevanssi.
Which doesn't require the `parse_query()` workaround.

Also I moved the filter from `the_posts` to `posts_pre_query` which should be a lot faster as it's triggered _Before_ WP_query does it's normal MySQL query.
As far as I can see this can't do any harm. If one uses the [relevanssi_do_query](https://www.relevanssi.com/user-manual/functions/relevanssi_do_query/) setup this part doesn't even get triggered.

Let me know what you think.