### PR TITLE
Allow customizing logged search term

### DIFF
--- a/lib/search.php
+++ b/lib/search.php
@@ -915,14 +915,14 @@ function relevanssi_do_query( &$query ) {
 		 * Filters whether the logged query includes synonyms or not.
 		 *
 		 * By default, Relevanssi logs the original query without the added
-		 * synonyms. If this filter hook returns true, Relevanssi will instead
-		 * log the query that contains the synonyms.
+		 * synonyms. This filters allows you to change this.
 		 *
-		 * @param boolean If true, log with synonyms. Default false.
+		 * @param string   $q_no_synonyms Default log sting without synonym.
+		 * @param string   $q             Searched string with synonym.
+		 * @param WP_Query $query         The WP_Query object which ran the
+		 *                                actual search.
 		 */
-		$query_string = apply_filters( 'relevanssi_log_synonyms', false )
-			? $q
-			: $q_no_synonyms;
+		$query_string = apply_filters( 'relevanssi_log_synonyms', $q_no_synonyms, $q, $query );
 		relevanssi_update_log( $query_string, $hits_count );
 	}
 

--- a/relevanssi.php
+++ b/relevanssi.php
@@ -14,6 +14,7 @@
  * Plugin URI: https://www.relevanssi.com/
  * Description: This plugin replaces WordPress search with a relevance-sorting search.
  * Version: 4.10.2
+ * Requires PHP: 7.1
  * Author: Mikko Saari
  * Author URI: http://www.mikkosaari.fi/
  * Text Domain: relevanssi

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -58,7 +58,7 @@ class LoggingTest extends WP_UnitTestCase {
 			),
 			array(
 				'query' => 'test',
-			),
+			)
 		);
 
 		update_option( 'relevanssi_trim_logs', 1 );


### PR DESCRIPTION
Part of [issue#30](https://github.com/msaari/relevanssi/issues/30).

Allow logged search term to be customized.
Added php version in plugin header.

There are over 60 php7.0 + lines. and a couple of 7.1+ lines. So installing the plugin in a PHP <7.1 will probably give fatal errors.

sample:
![image](https://user-images.githubusercontent.com/1026882/105983982-cb2e3d00-6099-11eb-9eee-d4ba028d2dc5.png)
