### PR TITLE
Fix: invalid docs index drop SQL

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -453,7 +453,7 @@ function relevanssi_create_database_tables( $relevanssi_db_version ) {
 		}
 
 		if ( $docs_exists ) { // This index was removed in 4.9.2 / 2.11.2.
-			$sql = "DROP INDEX docs ON $relevanssi_table (doc)";
+			$sql = "DROP INDEX docs ON $relevanssi_table";
 			$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery
 		}
 


### PR DESCRIPTION
I found the following notice on plugin activation which this fixes
```
NOTICE: PHP message: WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '(doc)' at line 1 for query DROP INDEX docs ON ts_relevanssi (doc) made by activate_plugin, do_action('activate_relevanssi-premium/relevanssi.php'), WP_Hook->do_action, WP_Hook->apply_filters, relevanssi_install, _relevanssi_install, relevanssi_create_database_tables
```