### PR TITLE
Add phpcs with PHPCompatibility configured

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,18 @@
         "php": "^7.0 || ^8.0"
     },
     "require-dev": {
-        "rask/wp-test-framework": "^0.2.0"
+        "rask/wp-test-framework": "^0.2.0",
+        "squizlabs/php_codesniffer": "^3.5",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "keywords": [
         "search",
         "WordPress",
         "plugin"
-    ]
+    ],
+    "scripts": {
+        "lint": "phpcs -p -s"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpcompatibility/phpcompatibility-wp": "^2.1"
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "wp-coding-standards/wpcs": "*"
     },
     "keywords": [
         "search",
@@ -34,6 +35,6 @@
         "plugin"
     ],
     "scripts": {
-        "lint": "phpcs -p -s"
+        "lint": "./vendor/bin/phpcs -p -s"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,8 +13,8 @@
     <rule ref="PHPCompatibility"/>
     <rule ref="PHPCompatibilityWP"/>
     <rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra"/>
+    <rule ref="WordPress-Docs"/>
+    <rule ref="WordPress-Extra"/>
     
     <config name="testVersion" value="7.0-"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,7 @@
 
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>/.history/*</exclude-pattern>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
@@ -11,6 +12,9 @@
 
     <rule ref="PHPCompatibility"/>
     <rule ref="PHPCompatibilityWP"/>
-
+    <rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra"/>
+    
     <config name="testVersion" value="7.0-"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset>
+    <file>.</file>
+
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="PHPCompatibility"/>
+    <rule ref="PHPCompatibilityWP"/>
+
+    <config name="testVersion" value="7.0-"/>
+</ruleset>


### PR DESCRIPTION
Running `composer lint` will check if the PHP code is compatible with PHP 7 and upwards.
- I excluded tests because I'm not sure how they run currently and if they have to be compatible with PHP 7+ as well (there are a few errors)
- `phpcs.xml.dist` would be the right place to add any coding styles the project adheres to in the future if wanted

This could be run manually for releases or automatically in some kind of CI.

phpcs can be speed up by running multiple processes in parallel. This might be relevant if the configuration / standards grow.