### PR TITLE
Silence PHP 8.4 deprecations, bump minimum PHP to 7.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= TDB =
+* Minor fix: Silence PHP 8.4 deprecations from implicitly nullable parameters
+
 = 4.22.2 =
 * Security fix: Prevent CSV injection attack in log export.
 * Security fix: Restrict access to doc count updates.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.0 || ^8.0"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "msaari/wp-test-framework": "^0.3.0",

--- a/lib/common.php
+++ b/lib/common.php
@@ -1022,7 +1022,7 @@ function relevanssi_add_highlight( $permalink, $link_post = null ) {
  * $post ID. Default null.
  * @return boolean True if the post ID or global $post matches the front page.
  */
-function relevanssi_is_front_page_id( int $post_id = null ): bool {
+function relevanssi_is_front_page_id( ?int $post_id = null ): bool {
 	$frontpage_id = intval( get_option( 'page_on_front' ) );
 	if ( $post_id === $frontpage_id ) {
 		return true;
@@ -1847,7 +1847,7 @@ function relevanssi_replace_synonyms_in_terms( array $terms ): array {
  * @return array An array of words with stemmed words replaced with their
  * originals.
  */
-function relevanssi_replace_stems_in_terms( array $terms, array $all_terms = null ): array {
+function relevanssi_replace_stems_in_terms( array $terms, ?array $all_terms = null ): array {
 	if ( ! $all_terms ) {
 		$all_terms = $terms;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.relevanssi.com/buy-premium/
 Tags: search, relevance, better search, product search, woocommerce search
 Requires at least: 4.9
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.1
 Stable tag: 4.24.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
First, I fully understand and respect the desire to work on as many installs as possible, and can completely understand not merging this just to silence some deprecation noise in the logs. If anything, this might just be for my own reference.

PHP 8.4 has deprecated implicitly nullable parameters that have explicit types declared. So `function test(string $a = null)` will be flagged because it is typed as a `string`, but can also be `null` by virtue of the default. Going forward either the type or default needs to be removed, or it needs to be explicit, either `?string` or `string|null`. The former was introduced in [PHP 7.1](https://wiki.php.net/rfc/nullable_types) while the latter was introduced in [PHP 8.0](https://wiki.php.net/rfc/union_types_v2).

More here: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

There's a handful of functions that use ` = null` but only two that I noticed that are typed which this PR addresses.